### PR TITLE
add typos check to ci

### DIFF
--- a/.github/config/typos.toml
+++ b/.github/config/typos.toml
@@ -1,0 +1,60 @@
+[default]
+binary = false
+check-filename = true
+extend-ignore-identifiers-re = [
+    "PNGs",
+    "_EDE_",
+    "ETyp",
+    "(p)assing",
+]
+
+[default.extend-words]
+alloced = "alloced"
+s2nd = "s2nd"
+nd = "nd"
+Inforce = "Inforce"
+ 
+# While we build up the extend-words list
+[type.cpp]
+check-file = false
+
+[type.c]
+check-file = false
+
+[type.py]
+check-file = false
+
+[type.make]
+check-file = false
+
+[type.cmake]
+check-file = false
+
+[type.rust]
+check-file = false
+
+[type.sh]
+check-file = false
+
+[files]
+extend-exclude = [
+    "**/corpus/*",
+    "**/mime.types",
+    "**/specs/**/*",
+    "*.bin",
+    "*.conf",
+    "*.cry",
+    "*.der",
+    "*.h",
+    "*.kat",
+    "*.patch",
+    "*.pcap",
+    "*.pdf",
+    "*.pem",
+    "*.png",
+    "*.priv",
+    "*.saw",
+    "*.snap",
+    "*.suppressions",
+    "tests/integrationv2/README.md",
+]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,30 @@ on:
     branches: [main]
 
 jobs:
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install rust toolchain
+        id: toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup override set stable
+
+      - uses: camshaft/install@v1
+        with:
+          crate: typos-cli
+          bins: typos
+
+      - name: Run typos
+        run: |
+          ./scripts/typos --format json | tee /tmp/typos.json | jq -rs '.[] | "::error file=\(.path),line=\(.line_num),col=\(.byte_offset)::\(.typo) should be \"" + (.corrections // [] | join("\" or \"") + "\"")'
+          cat /tmp/typos.json
+          ! grep -q '[^[:space:]]' /tmp/typos.json
+
   generate-doxygen:
     runs-on: ubuntu-latest
     steps:

--- a/docs/usage-guide/topics/ch07-io.md
+++ b/docs/usage-guide/topics/ch07-io.md
@@ -192,7 +192,7 @@ or if called on a connection in a bad state.
 
 `s2n_shutdown()` may also read and decrypt multiple application data records while waiting
 for the close_notify alert. This could result in calls to `s2n_shutdown()` taking a long
-time to complete. If this is a problem, `s2n_shutdown_send()` may be preferrable.
+time to complete. If this is a problem, `s2n_shutdown_send()` may be preferable.
 See [Closing the connection for writes](#closing-the-connection-for-writes) below.
 
 Once `s2n_shutdown()` is complete:

--- a/scripts/typos
+++ b/scripts/typos
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if ! command -v typos &> /dev/null; then
+    cargo install typos-cli
+fi
+
+eval typos -c .github/config/typos.toml $@

--- a/tests/README.md
+++ b/tests/README.md
@@ -44,7 +44,7 @@ Further information:
 s2n-tls includes a variety of formal methods which are used to _prove_ that s2n-tls has certain behaviors.
 
 ### CBMC
-> CBMC verifies memory safety (which includes array bounds checks and checks for the safe use of pointers), checks for various further variants of undefined behavior, and user-specified as­ser­tions.
+> CBMC verifies memory safety (which includes array bounds checks and checks for the safe use of pointers), checks for various further variants of undefined behavior, and user-specified assertions.
 > [C Bounded Model Checker](https://www.cprover.org/cbmc/)
 
 s2n-tls writes CBMC proofs for a number of sensitive or commonly used functions in the codebase.

--- a/tests/saw/spec/extras/HMAC/README.md
+++ b/tests/saw/spec/extras/HMAC/README.md
@@ -1,7 +1,7 @@
 These are files detailing the verification of HMAC with respect to the
 HMAC specification provided by Andrew Appel's HMAC verification effort.
 
-The files in this repository constitue a proof of equivalence between
+The files in this repository constitute a proof of equivalence between
 the [Cryptol specification of HMAC](../../HMAC.cry) and the [HMAC
 specification](HMAC_spec.v) used for the FCF proof of HMAC.
 


### PR DESCRIPTION
Followed the s2n-quic example, as #5051 suggests. Running CI here to verify that this does, indeed catch typos.

If anyone's reading this, I'm using this PR to compare the changes and run CI before I pollute a PR in the real repo (I'm very bad at getting CI jobs right on the first try).